### PR TITLE
nablarch-parentの除去時にnameタグなどの定義が漏れていたため追加

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,10 @@
   <artifactId>nablarch-unpublished-api-checker</artifactId>
   <version>1.0.1-SNAPSHOT</version>
 
+  <name>${project.artifactId}</name>
+  <description>Checker for unpublished API in Nablarch Framework.</description>
+  <url>https://github.com/nablarch</url>
+
   <licenses>
     <license>
       <name>The Apache License, Version 2.0</name>


### PR DESCRIPTION
nablarch-parentの除去時にnameタグなどの定義が漏れていたため追加しました。
（OSSRH上でステージングに反映する際に以下のエラーとなり検知しました。）
```
Invalid POM: /com/nablarch/framework/nablarch-unpublished-api-checker/1.0.1/nablarch-unpublished-api-checker-1.0.1.pom: Project name missing, Project description missing, Project URL missing
```